### PR TITLE
Skip creating branch if no targets exist

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Check if release target exists by comparing the production branch and the default branch
         run: |
-          git log --merges refs/remotes/origin/$GIT_PR_RELEASE_BRANCH_PRODUCTION..$(git symbolic-ref refs/remotes/origin/HEAD) --pretty=format:%h > commits.txt
+          git log --merges origin/$GIT_PR_RELEASE_BRANCH_PRODUCTION..origin/$(git branch --show-current) --pretty=format:%h > commits.txt
           test -s commits.txt # if file is not empty, it goes to the next step
 
       - name: Check if release branch exists

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -45,6 +45,11 @@ jobs:
           fetch-depth: 0 # Need to fetch merge history
           ref: ${{ github.event.inputs.branch_name }} # checkout branch
 
+      - name: Check if release target exists by comparing the production branch and the default branch
+        run: |
+          git log --merges refs/remotes/origin/$GIT_PR_RELEASE_BRANCH_PRODUCTION..$(git symbolic-ref refs/remotes/origin/HEAD) --pretty=format:%h > commits.txt
+          test -s commits.txt # if file is not empty, it goes to the next step
+
       - name: Check if release branch exists
         if: ${{ !inputs.override }}
         run: |


### PR DESCRIPTION
## Issue

closes https://github.com/smartbank-inc/release-pr-workflow/issues/7

## Change

This pull request adds a new step to check if the workflow should create a release branch or not.