### PR TITLE
Relax Ruby version

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -63,7 +63,6 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.0.3
           bundler-cache: true
 
       - name: Create a release pull request


### PR DESCRIPTION
## Issue

closes #8 

## Change

https://github.com/ruby/setup-ruby does not require `ruby-version` option. If the option is not given, the action looks up `.ruby-version` file.