### PR TITLE
Determine version dynamically

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -60,9 +60,19 @@ jobs:
           git switch -c $GIT_PR_RELEASE_BRANCH_STAGING
           git push origin $GIT_PR_RELEASE_BRANCH_STAGING
 
+      - name: Determine which Ruby version to use
+        id: ruby-version-check
+        run: |
+          if [ -e ".ruby-version" ]; then
+            echo ::set-output name=users::.ruby-version
+          else
+            echo ::set-output name=users::3.1.2
+          fi
+
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
+          ruby-version: ${{ steps.ruby-version-check.outputs.version }}
           bundler-cache: true
 
       - name: Create a release pull request

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -64,9 +64,9 @@ jobs:
         id: ruby-version-check
         run: |
           if [ -e ".ruby-version" ]; then
-            echo ::set-output name=users::.ruby-version
+            echo ::set-output name=version::.ruby-version
           else
-            echo ::set-output name=users::3.1.2
+            echo ::set-output name=version::3.1.2
           fi
 
       - name: Set up Ruby


### PR DESCRIPTION
## Issue

Closes #12

I found https://github.com/smartbank-inc/release-pr-workflow/pull/10/files is a wrong way to fix.

Because `ruby/setup-ruby` action fails if the repository does not have neither `.ruby-version` nor `.tool-versions`. So it needs to pass a default value when missing those files.

## Change

See https://github.com/smartbank-inc/release-pr-workflow/issues/12#issuecomment-1102277808