### PR TITLE
Use exactly match to check if branch exists

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Check if release branch exists
         if: ${{ !inputs.override }}
         run: |
-          ! (git branch -a | grep -c "remotes/origin/$GIT_PR_RELEASE_BRANCH_STAGING")
+          ! (git branch -a --format="%(refname:short)" | grep -cx "origin/$GIT_PR_RELEASE_BRANCH_STAGING")
 
       - name: Create new Branch
         run: |


### PR DESCRIPTION
## Issue

Closes https://github.com/smartbank-inc/release-pr-workflow/issues/13

## Change

branchの存在チェックを完全一致で行うようにした。

This pull request makes it to use exactly match when checking branch existence.

## References

- git branch --format
    - it's necessary to trim its output
    - https://git-scm.com/docs/git-branch#Documentation/git-branch.txt---formatltformatgt
    - https://git-scm.com/docs/git-for-each-ref
- grep -x
    - use `-x` for exactly match
    - https://linuxcommand.org/lc3_man_pages/grep1.html
