### PR TITLE
Stop using deprecated `set-output` command

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -64,9 +64,9 @@ jobs:
         id: ruby-version-check
         run: |
           if [ -e ".ruby-version" ]; then
-            echo ::set-output name=version::.ruby-version
+            echo "version=.ruby-version" >> "${GITHUB_OUTPUT}"
           else
-            echo ::set-output name=version::3.1.2
+            echo "version=3.1.2" >> "${GITHUB_OUTPUT}"
           fi
 
       - name: Set up Ruby
@@ -86,8 +86,8 @@ jobs:
           gh pr view $GIT_PR_RELEASE_BRANCH_STAGING --json "body,number" -t '{{ .number }}{{ printf "\n" }}{{ .body }}' > pr.txt
           users=$(grep -o -E '@[A-z]+' pr.txt | sort -u | xargs echo)
           number=$(head -n 1 pr.txt)
-          echo ::set-output name=users::$users
-          echo ::set-output name=number::$number
+          echo "users=${users}" >> "${GITHUB_OUTPUT}"
+          echo "number=${number}" >> "${GITHUB_OUTPUT}"
 
       - name: Notify of Slack
         uses: rtCamp/action-slack-notify@v2

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -64,9 +64,9 @@ jobs:
         id: ruby-version-check
         run: |
           if [ -e ".ruby-version" ]; then
-            echo "version=.ruby-version" >> "${GITHUB_OUTPUT}"
+            echo "version=.ruby-version" >> $GITHUB_OUTPUT
           else
-            echo "version=3.1.2" >> "${GITHUB_OUTPUT}"
+            echo "version=3.1.2" >> $GITHUB_OUTPUT
           fi
 
       - name: Set up Ruby
@@ -86,8 +86,8 @@ jobs:
           gh pr view $GIT_PR_RELEASE_BRANCH_STAGING --json "body,number" -t '{{ .number }}{{ printf "\n" }}{{ .body }}' > pr.txt
           users=$(grep -o -E '@[A-z]+' pr.txt | sort -u | xargs echo)
           number=$(head -n 1 pr.txt)
-          echo "users=${users}" >> "${GITHUB_OUTPUT}"
-          echo "number=${number}" >> "${GITHUB_OUTPUT}"
+          echo "users=${users}" >> $GITHUB_OUTPUT
+          echo "number=${number}" >> $GITHUB_OUTPUT
 
       - name: Notify of Slack
         uses: rtCamp/action-slack-notify@v2


### PR DESCRIPTION
I found the deprecation warning below that comes from this workflow.

```
Warning: The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
```

This pull request stops using `set-output` and starts using `$GITHUB_OUTPUT` env.


ref https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/