### PR TITLE
Bump actions/checkout to v3

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -40,7 +40,7 @@ jobs:
       GIT_PR_RELEASE_TEMPLATE: ${{ inputs.git_pr_release_template }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0 # Need to fetch merge history
           ref: ${{ github.event.inputs.branch_name }} # checkout branch


### PR DESCRIPTION
This pull request bumps actions/checkout to v3 since v2 uses Node v12 that is going to be stopped. 


ref https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/