### PR TITLE
Use more reasonable regex for GitHub username

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -84,7 +84,7 @@ jobs:
         id: fetch
         run: |
           gh pr view $GIT_PR_RELEASE_BRANCH_STAGING --json "body,number" -t '{{ .number }}{{ printf "\n" }}{{ .body }}' > pr.txt
-          users=$(grep -o -E '@[A-z]+' pr.txt | sort -u | xargs echo)
+          users=$(grep -o -E "^@[a-zA-Z0-9]([a-zA-Z0-9]?|[\-]?([a-zA-Z0-9])){0,38}$" pr.txt | sort -u | xargs echo)
           number=$(head -n 1 pr.txt)
           echo "users=${users}" >> $GITHUB_OUTPUT
           echo "number=${number}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Issue

The current regex to extract GitHub username is not complete. It ignores numbers, `-` and etc.

## Change

This pull request starts to use more reasonable regex for those usernames.


ref https://qiita.com/KEINOS/items/34041c94913b7bed7431