### PR TITLE
feat: add Slack notification for existing release branch

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -51,9 +51,31 @@ jobs:
           test -s commits.txt # if file is not empty, it goes to the next step
 
       - name: Check if release branch exists
+        id: branch-check
         if: ${{ !inputs.override }}
         run: |
-          ! (git branch -a --format="%(refname:short)" | grep -cx "origin/$GIT_PR_RELEASE_BRANCH_STAGING")
+          if git branch -a --format="%(refname:short)" | grep -qx "origin/$GIT_PR_RELEASE_BRANCH_STAGING"; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Notify if branch already exists
+        if: ${{ !inputs.override && steps.branch-check.outputs.exists == 'true' }}
+        uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661 # v2.3.3
+        env:
+          SLACK_WEBHOOK: ${{ secrets.slack_webhook }}
+          SLACK_COLOR: "warning"
+          SLACK_TITLE: "${{ github.repository }} - Release branch already exists"
+          SLACK_MESSAGE: "The release branch '${{ inputs.git_pr_release_branch_staging }}' already exists. Please merge or delete the existing branch before creating a new one."
+          SLACK_FOOTER: ""
+          MSG_MINIMAL: true
+
+      - name: Exit if branch already exists
+        if: ${{ !inputs.override && steps.branch-check.outputs.exists == 'true' }}
+        run: |
+          echo "Error: Release branch already exists. Exiting."
+          exit 1
 
       - name: Create new Branch
         run: |


### PR DESCRIPTION
## Motivation

Previously, when a release branch already existed, the workflow would fail silently at the branch check step. This made it difficult for users to understand what went wrong. With this change, users receive a clear Slack notification explaining the situation and what action to take.


## Changes
- Modified branch existence check to output result instead of failing directly
- Added Slack notification step to alert when branch already exists
- Added explicit error exit after notification for clear workflow termination


## Testing

It works 💯 

<img width="1190" height="228" alt="CleanShot 2025-12-09 at 17 30 17@2x" src="https://github.com/user-attachments/assets/b16a1c46-9cfe-4ca3-b502-20b879a60c48" />
