### PR TITLE
Replace rtCamp/action-slack-notify with slackapi/slack-github-action

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -62,14 +62,18 @@ jobs:
 
       - name: Notify if branch already exists
         if: ${{ !inputs.override && steps.branch-check.outputs.exists == 'true' }}
-        uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661 # v2.3.3
-        env:
-          SLACK_WEBHOOK: ${{ secrets.slack_webhook }}
-          SLACK_COLOR: "warning"
-          SLACK_TITLE: "${{ github.repository }} - Release branch already exists"
-          SLACK_MESSAGE: "The release branch '${{ inputs.git_pr_release_branch_staging }}' already exists. Please merge or delete the existing branch before creating a new one."
-          SLACK_FOOTER: ""
-          MSG_MINIMAL: true
+        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
+        with:
+          webhook: ${{ secrets.slack_webhook }}
+          webhook-type: incoming-webhook
+          payload: |
+            attachments:
+              - color: "warning"
+                blocks:
+                  - type: "section"
+                    text:
+                      type: "mrkdwn"
+                      text: "*${{ github.repository }} - Release branch already exists*\nThe release branch '${{ inputs.git_pr_release_branch_staging }}' already exists. Please merge or delete the existing branch before creating a new one."
 
       - name: Exit if branch already exists
         if: ${{ !inputs.override && steps.branch-check.outputs.exists == 'true' }}
@@ -112,12 +116,15 @@ jobs:
           echo "number=${number}" >> $GITHUB_OUTPUT
 
       - name: Notify of Slack
-        uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661 # v2.3.3
-        env:
-          SLACK_WEBHOOK: ${{ secrets.slack_webhook }}
-          SLACK_COLOR: "#1DD0B0"
-          SLACK_TITLE: "${{ github.repository }} has changes to be released!"
-          SLACK_MESSAGE: "Check https://github.com/${{ github.repository }}/pull/${{ steps.fetch.outputs.number }} ${{ steps.fetch.outputs.users }} "
-          SLACK_FOOTER: ""
-          SLACK_LINK_NAMES: true
-          MSG_MINIMAL: true
+        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
+        with:
+          webhook: ${{ secrets.slack_webhook }}
+          webhook-type: incoming-webhook
+          payload: |
+            attachments:
+              - color: "#1DD0B0"
+                blocks:
+                  - type: "section"
+                    text:
+                      type: "mrkdwn"
+                      text: "*${{ github.repository }} has changes to be released!*\nCheck <https://github.com/${{ github.repository }}/pull/${{ steps.fetch.outputs.number }}|PR #${{ steps.fetch.outputs.number }}> ${{ steps.fetch.outputs.users }}"


### PR DESCRIPTION
## Summary
- Replace unofficial `rtCamp/action-slack-notify` with official `slackapi/slack-github-action@v2.1.1`
- Use Block Kit attachments to preserve colored message styling
- Convert PR links to Slack mrkdwn format for better rendering

## Why
- Official Slack maintenance and support
- Better documentation
- Regular security updates from Slack team

## Test plan

- [x] Trigger workflow normally to verify success notification with PR link and user mentions
- [x] Trigger workflow with existing release branch to verify warning notification

<img width="1186" height="550" alt="CleanShot 2025-12-10 at 22 15 18@2x" src="https://github.com/user-attachments/assets/165694f2-6215-4784-b743-fe26e28f5b37" />



Closes #36