### PR TITLE
chore(deps): update GitHub Actions dependencies

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -58,7 +58,7 @@ jobs:
       GIT_PR_RELEASE_REQUEST_PR_AUTHOR_REVIEW: ${{ inputs.git_pr_release_request_pr_author_review }}
     steps:
       - name: Checkout
-        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           fetch-depth: 0 # Need to fetch merge history
           ref: ${{ github.event.inputs.branch_name }} # checkout branch
@@ -114,7 +114,7 @@ jobs:
           fi
 
       - name: Set up Ruby
-        uses: ruby/setup-ruby@8aeb6ff8030dd539317f8e1769a044873b56ea71 # v1.268.0
+        uses: ruby/setup-ruby@d354de180d0c9e813cfddfcbdc079945d4be589b # v1.275.0
         with:
           ruby-version: ${{ steps.ruby-version-check.outputs.version }}
           bundler-cache: true


### PR DESCRIPTION
## Summary
- Bump actions/checkout from v6.0.0 to v6.0.1
- Bump ruby/setup-ruby from v1.268.0 to v1.275.0