### PR TITLE
Update ruby/setup-ruby version to use Ruby 4.0.2

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -114,7 +114,7 @@ jobs:
           fi
 
       - name: Set up Ruby
-        uses: ruby/setup-ruby@09a7688d3b55cf0e976497ff046b70949eeaccfd # v1.288.0
+        uses: ruby/setup-ruby@319994f95fa847cf3fb3cd3dbe89f6dcde9f178f # v1.295.0
         with:
           ruby-version: ${{ steps.ruby-version-check.outputs.version }}
           bundler-cache: true


### PR DESCRIPTION
This workflow users cannot use Ruby v4.0.2 due to the old ruby/setup-ruby version. This PR bumps it to the latest.