### PR TITLE
schedule実行時にリリースブランチの存在チェックをスキップする

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -70,7 +70,7 @@ jobs:
 
       - name: Check if release branch exists
         id: branch-check
-        if: ${{ !inputs.override }}
+        if: ${{ !inputs.override && github.event_name != 'schedule' }}
         run: |
           if git branch -a --format="%(refname:short)" | grep -qx "origin/$GIT_PR_RELEASE_BRANCH_STAGING"; then
             echo "exists=true" >> $GITHUB_OUTPUT
@@ -79,7 +79,7 @@ jobs:
           fi
 
       - name: Notify if branch already exists
-        if: ${{ !inputs.override && steps.branch-check.outputs.exists == 'true' }}
+        if: ${{ !inputs.override && github.event_name != 'schedule' && steps.branch-check.outputs.exists == 'true' }}
         uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
         with:
           webhook: ${{ secrets.slack_webhook }}
@@ -94,7 +94,7 @@ jobs:
                       text: "*${{ github.repository }} - Release branch already exists*\nThe release branch '${{ inputs.git_pr_release_branch_staging }}' already exists. Please merge or delete the existing branch before creating a new one."
 
       - name: Exit if branch already exists
-        if: ${{ !inputs.override && steps.branch-check.outputs.exists == 'true' }}
+        if: ${{ !inputs.override && github.event_name != 'schedule' && steps.branch-check.outputs.exists == 'true' }}
         run: |
           echo "Error: Release branch already exists. Exiting."
           exit 1


### PR DESCRIPTION
> [11:17](https://smartbankhq.slack.com/archives/C01FPAK82U8/p1774923435372669)（定期実行なら必ず override: true でもいいのかも）from Slack

## Summary

- schedule実行時、リリースブランチが既に存在していてもブランチ存在チェックをスキップしてワークフローを続行するようにした
- 定期実行でリリースPRが未マージのまま翌日を迎えた場合にワークフローが失敗する問題を解消する
- 手動実行（workflow_dispatch）時の安全弁（ブランチ重複チェック）は従来通り維持

## 変更内容

ブランチ存在チェックに関わる3ステップのif条件に `github.event_name != 'schedule'` を追加。`inputs.override == true` または schedule実行のいずれかで、チェックをスキップする。

🤖 Generated with [Claude Code](https://claude.com/claude-code)